### PR TITLE
Fix require for local node_modules (#255 and #259)

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,9 +60,18 @@ var Require = {
             // Try local first.
             // Here we have to require from the node_modules directory directly.
 
-            var moduleDir = path.join(path.dirname(file), "node_modules");
+            var moduleDir = path.dirname(file);
+            while (moduleDir.length > 1) {
+              try {
+                return require(path.join(moduleDir, 'node_modules', pkgPath));
+              } catch (e) {
+
+              }
+              moduleDir = path.join(moduleDir, '..');
+            }
+
             try {
-              return require(path.join(moduleDir, pkgPath));
+              return require(path.join(moduleDir, 'node_modules', pkgPath));
             } catch (e) {
 
             }

--- a/index.js
+++ b/index.js
@@ -61,19 +61,17 @@ var Require = {
             // Here we have to require from the node_modules directory directly.
 
             var moduleDir = path.dirname(file);
-            while (moduleDir.length > 1) {
+            while (true) {
               try {
                 return require(path.join(moduleDir, 'node_modules', pkgPath));
               } catch (e) {
 
               }
+              var oldModuleDir = moduleDir;
               moduleDir = path.join(moduleDir, '..');
-            }
-
-            try {
-              return require(path.join(moduleDir, 'node_modules', pkgPath));
-            } catch (e) {
-
+              if (moduleDir === oldModuleDir) {
+                break;
+              }
             }
 
             // Try global, and let the error throw.


### PR DESCRIPTION
## `require('local_node_module')` is not working.

https://github.com/trufflesuite/truffle/issues/383
https://github.com/trufflesuite/truffle/issues/255
https://github.com/trufflesuite/truffle/issues/259

In 3.1.10, global node_modules problem is fixed, but local case is not.

For example, we are using following truffle project.
If execute `truffle exec ext/sample.js`, Truffle searches only `./ext/node_modules`, but using `./node_modules` is natural.
https://github.com/trufflesuite/truffle-require/blob/master/index.js#L63-L68

```
/home/user/myProject/
.
+ build/
+ contracts/
+ ext/
    + sample.js <- contains `require('local_node_module')`
+ migrations/
+ node_modules/
    + local_node_module
+ test/
+ truffle.js
```
Node.js looks in following order.
`/home/user/myProject/ext/node_modules` ->  `/home/user/myProject/node_modules` -> `/home/user/node_modules` -> `/home/node_modules` -> `/node_modules`
https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders

This PR fixes this difference.