### PR TITLE
Tests for pesky require statements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "truffle-require",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Require and execute a Javascript module within a Truffle context",
-  "main": "index.js",
+  "main": "require.js",
   "scripts": {
     "test": "mocha"
   },
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-exec#readme",
   "devDependencies": {
-    "mocha": "^3.2.0"
+    "mocha": "^3.4.2"
   },
   "dependencies": {
     "truffle-config": "0.0.6",

--- a/require.js
+++ b/require.js
@@ -17,8 +17,7 @@ var Require = {
     var file = options.file;
 
     expect.options(options, [
-      "file",
-      "resolver"
+      "file"
     ]);
 
     options = Config.default().with(options);

--- a/test/internal_requires.js
+++ b/test/internal_requires.js
@@ -1,0 +1,63 @@
+var Require = require("../");
+var path = require("path");
+var assert = require("assert");
+var mocha = require("mocha"); // Used as an example of a locally installed module.
+
+describe("Require", function() {
+
+  it("allows internal require statements for globally installed modules", function(done) {
+    Require.file({
+      file: path.join(__dirname, "lib", "module_with_global_require.js")
+    }, function(err, exports) {
+      if (err) return done(err);
+
+      // It should export a function. Call the function.
+      var obj = exports();
+
+      // It should return the path object. This should be the same object
+      // as the one we required at the top of this file.
+      assert.equal(obj, path);
+
+      done();
+    });
+  });
+
+  it("allows require statements for local files", function(done) {
+    Require.file({
+      file: path.join(__dirname, "lib", "module_with_local_file_require.js")
+    }, function(err, exports) {
+      if (err) return done(err);
+
+      // It should export a function, which, since we're using the global require in
+      // the file, should be a function that returns the same function exported
+      // in the test above.
+      var module_with_global_require = exports();
+
+      // Let's ride this train all the way down to path.
+      var obj = module_with_global_require();
+
+      // It should return the path object. This should be the same object
+      // as the one we required at the top of this file.
+      assert.equal(obj, path);
+
+      done();
+    });
+  });
+
+  it("allows require statements for locally install modules (node_modules)", function() {
+    Require.file({
+      file: path.join(__dirname, "lib", "module_with_local_module_require.js")
+    }, function(err, exports) {
+      if (err) return done(err);
+
+      // It should export a function. Call the function.
+      var obj = exports();
+
+      // It should return the mocha object. This should be the same object
+      // as the one we required at the top of this file.
+      assert.equal(obj, mocha);
+
+      done();
+    });
+  });
+})

--- a/test/lib/module_with_global_require.js
+++ b/test/lib/module_with_global_require.js
@@ -1,0 +1,5 @@
+var path = require("path");
+
+module.exports = function() {
+  return path;
+}

--- a/test/lib/module_with_local_file_require.js
+++ b/test/lib/module_with_local_file_require.js
@@ -1,0 +1,6 @@
+var path = require("path");
+var module_with_global_require = require(path.join(__dirname, "module_with_global_require.js"));
+
+module.exports = function() {
+  return module_with_global_require;
+}

--- a/test/lib/module_with_local_module_require.js
+++ b/test/lib/module_with_local_module_require.js
@@ -1,0 +1,6 @@
+// mocha is a dependency of truffle-require, thus it is locally installed.
+var mocha = require("mocha");
+
+module.exports = function() {
+  return mocha;
+}


### PR DESCRIPTION
Add tests for three types of require statements within files that use truffle-require. Also rename index.js to require.js per our new standard.