### PR TITLE
feat: transform required code with babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "mocha": "^3.4.2"
   },
   "dependencies": {
+    "babel-core": "^6.25.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-runtime": "^6.25.0",
     "original-require": "^1.0.1",
     "truffle-config": "^1.0.1",
     "truffle-expect": "^0.0.3",

--- a/test/internal_requires.js
+++ b/test/internal_requires.js
@@ -60,4 +60,21 @@ describe("Require", function() {
       done();
     });
   });
+
+  it("correctly compiles es6 code with babel", function() {
+    Require.file({
+      file: path.join(__dirname, "lib", "module_with_es6_features.js")
+    }, function(err, exports) {
+      if (err) return done(err);
+
+      // It should export a function. Call the function.
+      var obj = exports();
+
+      // It should return the path object. This should be the same object
+      // as the one we required at the top of this file.
+      assert.equal(obj, path);
+
+      done();
+    });
+  });
 })

--- a/test/lib/module_with_es6_features.js
+++ b/test/lib/module_with_es6_features.js
@@ -1,0 +1,3 @@
+import path from 'path'
+
+export default async arg => path


### PR DESCRIPTION
This PR allows migration files to be written in es6 syntax. For example:

```js
const Migrations = artifacts.require('Migrations')

export default async deployer => {
  await deployer.deploy(Migrations)
}
```

---

It is paired with PRs on `truffle-migrate` and `truffle-core`.

- [truffle-migrate#13](https://github.com/trufflesuite/truffle-migrate/pull/13)
- [truffle-core#33](https://github.com/trufflesuite/truffle-core/pull/33)